### PR TITLE
Adding ability to render relationships only

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,7 +551,7 @@ Example above produces this output (made readable for docs):
 }
 ```
 
-By default usage of `serialize(includes: ...)` resializes relationships and includes related objects in `includes: ...` array. You able to serialize relationships only by using `FastJSONAPISerializer::RelationshipConfig`, example:
+By default usage of `serialize(includes: ...)` serializes relationships and includes related objects in `includes: ...` array. But you able to serialize relationships only by using `FastJSONAPISerializer::RelationshipConfig`, example:
 
 ```crystal
 serialization_config = FastJSONAPISerializer::RelationshipConfig.parse(
@@ -566,7 +566,7 @@ RestaurantSerializer.new(resource).serialize(includes: serialization_config)
 
 ```
 
-The code above produce:
+The code above produces:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -551,6 +551,81 @@ Example above produces this output (made readable for docs):
 }
 ```
 
+By default usage of `serialize(includes: ...)` resializes relationships and includes related objects in `includes: ...` array. You able to serialize relationships only by using `FastJSONAPISerializer::RelationshipConfig`, example:
+
+```crystal
+serialization_config = FastJSONAPISerializer::RelationshipConfig.parse(
+  {
+    :address   => [:address],
+    :post_code => [:post_code],
+    :tables    => {:room => [:room]}, # notice nested associations also
+  }
+)
+serialization_config.relationship(:tables).include?(false)
+RestaurantSerializer.new(resource).serialize(includes: serialization_config)
+
+```
+
+The code above produce:
+
+```json
+{
+  "data": {
+    "id": "1",
+    "type": "restaurant",
+    "attributes": {
+      "name": "big burgers"
+    },
+    "relationships": {
+      "address": {
+        "data": {
+          "id": "101",
+          "type": "address"
+        }
+      },
+      "post_code": {
+        "data": {
+          "id": "101",
+          "type": "post_code"
+        }
+      },
+      "Tables": {
+        "data": [
+          {
+            "id": "1",
+            "type": "table"
+          },
+          {
+            "id": "2",
+            "type": "table"
+          },
+          {
+            "id": "3",
+            "type": "table"
+          }
+        ]
+      }
+    }
+  },
+  "included": [
+    {
+      "id": "101",
+      "type": "address",
+      "attributes": {
+        "street": "some street"
+      }
+    },
+    {
+      "id": "101",
+      "type": "post_code",
+      "attributes": {
+        "code": "code 24"
+      }
+    }
+  ]
+}
+```
+
 ### Meta
 
 You can add meta details to the JSON response payload.

--- a/shard.yml
+++ b/shard.yml
@@ -1,7 +1,7 @@
 name: fast-jsonapi-serializer
 description: |
   FastJSONAPISerializer is a fast, flexible and simple JSON-API serializer for crystal
-version: 0.2.0
+version: 0.2.1
 
 authors:
   - Marc Jeffrey <mjeffrey18@gmail.com>

--- a/spec/fast-json-api-serializer/relationship_config_spec.cr
+++ b/spec/fast-json-api-serializer/relationship_config_spec.cr
@@ -1,0 +1,71 @@
+require "../spec_helper"
+
+describe FastJSONAPISerializer::RelationshipConfig do
+  context "when config contains hashes" do
+    it "parses configuration" do
+      configuration = { :a => { :b => :c } }
+      config = FastJSONAPISerializer::RelationshipConfig.parse(configuration)
+      config.included.should be_true
+      config.empty?.should be_false
+
+      expect_raises(FastJSONAPISerializer::RelationshipConfig::RelationshipMissingException) do
+        config.relationship(:a).relationship(:c)
+      end
+
+      config.has_relation?(:a).should be_true
+      config.relationship(:a).empty?.should be_false
+      config.relationship(:a).included.should be_true
+      config.has_relation?(:d).should be_false
+      config.nested(:d).included.should be_true
+
+      config.relationship(:a).has_relation?(:b).should be_true
+      config.relationship(:a).relationship(:b).empty?.should be_false
+      config.relationship(:a).relationship(:b).included.should be_true
+      config.relationship(:a).relationship(:b).has_relation?(:d).should be_false
+
+      config.relationship(:a).relationship(:b).include?(false)
+      config.relationship(:a).relationship(:b).empty?.should be_false
+      config.relationship(:a).relationship(:b).included.should be_false
+      config.relationship(:a).relationship(:b).has_relation?(:c).should be_true
+
+      config.relationship(:a).relationship(:b).relationship(:c).empty?.should be_true
+      config.relationship(:a).relationship(:b).relationship(:c).included.should be_false
+
+      config.nested(:d).nested(:g).included.should be_true
+    end
+  end
+
+  context "when config contains array" do
+    it "parses configuration" do
+      configuration = { :a => { :b => [:c] } }
+      config = FastJSONAPISerializer::RelationshipConfig.parse(configuration)
+      config.included.should be_true
+      config.empty?.should be_false
+
+      expect_raises(FastJSONAPISerializer::RelationshipConfig::RelationshipMissingException) do
+        config.relationship(:a).relationship(:c)
+      end
+
+      config.has_relation?(:a).should be_true
+      config.relationship(:a).empty?.should be_false
+      config.relationship(:a).included.should be_true
+      config.has_relation?(:d).should be_false
+      config.nested(:d).included.should be_true
+
+      config.relationship(:a).has_relation?(:b).should be_true
+      config.relationship(:a).relationship(:b).empty?.should be_false
+      config.relationship(:a).relationship(:b).included.should be_true
+      config.relationship(:a).relationship(:b).has_relation?(:d).should be_false
+
+      config.relationship(:a).relationship(:b).include?(false)
+      config.relationship(:a).relationship(:b).empty?.should be_false
+      config.relationship(:a).relationship(:b).included.should be_false
+      config.relationship(:a).relationship(:b).has_relation?(:c).should be_true
+
+      config.relationship(:a).relationship(:b).relationship(:c).empty?.should be_true
+      config.relationship(:a).relationship(:b).relationship(:c).included.should be_false
+
+      config.nested(:d).nested(:g).included.should be_true
+    end
+  end
+end

--- a/spec/fast-json-api-serializer/relationship_config_spec.cr
+++ b/spec/fast-json-api-serializer/relationship_config_spec.cr
@@ -3,7 +3,7 @@ require "../spec_helper"
 describe FastJSONAPISerializer::RelationshipConfig do
   context "when config contains hashes" do
     it "parses configuration" do
-      configuration = { :a => { :b => :c } }
+      configuration = {:a => {:b => :c}}
       config = FastJSONAPISerializer::RelationshipConfig.parse(configuration)
       config.included.should be_true
       config.empty?.should be_false
@@ -37,7 +37,7 @@ describe FastJSONAPISerializer::RelationshipConfig do
 
   context "when config contains array" do
     it "parses configuration" do
-      configuration = { :a => { :b => [:c] } }
+      configuration = {:a => {:b => [:c]}}
       config = FastJSONAPISerializer::RelationshipConfig.parse(configuration)
       config.included.should be_true
       config.empty?.should be_false

--- a/spec/fast-jsonapi-serializer_spec.cr
+++ b/spec/fast-jsonapi-serializer_spec.cr
@@ -154,7 +154,7 @@ describe FastJSONAPISerializer do
         it "adds relations objects and skips included data" do
           resource = Restaurant.new
           resource.address = Address.new
-          rel_config = FastJSONAPISerializer::RelationshipConfig.parse({ :address => [:address] })
+          rel_config = FastJSONAPISerializer::RelationshipConfig.parse({:address => [:address]})
           rel_config.include?(false)
           data = RestaurantSerializer.new(resource).serialize(includes: rel_config)
 
@@ -213,7 +213,7 @@ describe FastJSONAPISerializer do
         end
 
         it "includes only relationsips objects and skips embedding data" do
-          rel_config = FastJSONAPISerializer::RelationshipConfig.parse({ :post_code => [:post_code] }).include?(false)
+          rel_config = FastJSONAPISerializer::RelationshipConfig.parse({:post_code => [:post_code]}).include?(false)
           resource = Restaurant.new
           resource.post_code = PostCode.new
           data = RestaurantSerializer.new(resource).serialize(includes: rel_config)
@@ -275,7 +275,7 @@ describe FastJSONAPISerializer do
         it "adds relation objects and skips included data" do
           resource = Restaurant.new
           resource.rooms = [Room.new(1), Room.new(2)]
-          ref_config = FastJSONAPISerializer::RelationshipConfig.parse({ :rooms => [:rooms] }).include?(false)
+          ref_config = FastJSONAPISerializer::RelationshipConfig.parse({:rooms => [:rooms]}).include?(false)
           data = RestaurantSerializer.new(resource).serialize(includes: ref_config)
 
           data.should contain(%("relationships"))
@@ -342,10 +342,10 @@ describe FastJSONAPISerializer do
           resource.guests = [Guest.new(1), Guest.new(2)]
 
           ref_config = FastJSONAPISerializer::RelationshipConfig.parse({
-              :guests => {:friends => [:friends]},
-              :diners => [:diners],
-              :vips   => [:vips],
-            }
+            :guests => {:friends => [:friends]},
+            :diners => [:diners],
+            :vips   => [:vips],
+          }
           )
           ref_config.relationship(:guests).include?(false)
           data = RestaurantSerializer.new(resource).serialize(includes: ref_config)

--- a/spec/fast-jsonapi-serializer_spec.cr
+++ b/spec/fast-jsonapi-serializer_spec.cr
@@ -157,11 +157,11 @@ describe FastJSONAPISerializer do
           rel_config = FastJSONAPISerializer::RelationshipConfig.parse({ :address => [:address] })
           rel_config.include?(false)
           data = RestaurantSerializer.new(resource).serialize(includes: rel_config)
-          data.should contain(%("included"))
+
           data.should contain(%("relationships"))
 
           data.should eq(
-            "{\"data\":{\"id\":\"1\",\"type\":\"restaurant\",\"attributes\":{\"name\":\"big burgers\",\"Rating\":\"Great!\",\"own_field\":12},\"relationships\":{\"address\":{\"data\":{\"id\":\"101\",\"type\":\"address\"}}}},\"included\":[]}"
+            "{\"data\":{\"id\":\"1\",\"type\":\"restaurant\",\"attributes\":{\"name\":\"big burgers\",\"Rating\":\"Great!\",\"own_field\":12},\"relationships\":{\"address\":{\"data\":{\"id\":\"101\",\"type\":\"address\"}}}}}"
           )
           validate_json_integrity(data)
         end
@@ -217,10 +217,10 @@ describe FastJSONAPISerializer do
           resource = Restaurant.new
           resource.post_code = PostCode.new
           data = RestaurantSerializer.new(resource).serialize(includes: rel_config)
-          data.should contain(%("included"))
+
           data.should contain(%("relationships"))
           data.should eq(
-            "{\"data\":{\"id\":\"1\",\"type\":\"restaurant\",\"attributes\":{\"name\":\"big burgers\",\"Rating\":\"Great!\",\"own_field\":12},\"relationships\":{\"post_code\":{\"data\":{\"id\":\"101\",\"type\":\"post_code\"}}}},\"included\":[]}"
+            "{\"data\":{\"id\":\"1\",\"type\":\"restaurant\",\"attributes\":{\"name\":\"big burgers\",\"Rating\":\"Great!\",\"own_field\":12},\"relationships\":{\"post_code\":{\"data\":{\"id\":\"101\",\"type\":\"post_code\"}}}}}"
           )
           validate_json_integrity(data)
         end
@@ -277,11 +277,10 @@ describe FastJSONAPISerializer do
           resource.rooms = [Room.new(1), Room.new(2)]
           ref_config = FastJSONAPISerializer::RelationshipConfig.parse({ :rooms => [:rooms] }).include?(false)
           data = RestaurantSerializer.new(resource).serialize(includes: ref_config)
-          data.should contain(%("included"))
+
           data.should contain(%("relationships"))
           data.should eq(
-            "{\"data\":{\"id\":\"1\",\"type\":\"restaurant\",\"attributes\":{\"name\":\"big burgers\",\"Rating\":\"Great!\",\"own_field\":12},\"relationships\":{\"rooms\":{\"data\":[{\"id\":\"1\",\"type\":\"room\"},{\"id\":\"2\",\"type\":\"room\"}]}}}" +
-            ",\"included\":[]}"
+            "{\"data\":{\"id\":\"1\",\"type\":\"restaurant\",\"attributes\":{\"name\":\"big burgers\",\"Rating\":\"Great!\",\"own_field\":12},\"relationships\":{\"rooms\":{\"data\":[{\"id\":\"1\",\"type\":\"room\"},{\"id\":\"2\",\"type\":\"room\"}]}}}}"
           )
           validate_json_integrity(data)
         end
@@ -365,8 +364,8 @@ describe FastJSONAPISerializer do
             "\"diners\":{\"data\":[{\"id\":\"60\",\"type\":\"guest\"}]}," +
             "\"vips\":{\"data\":[{\"id\":\"1\",\"type\":\"guest\"}]}}}" +
             ",\"included\":[" +
-            "{\"id\":\"1\",\"type\":\"guest\",\"attributes\":{\"age\":25,\"name\":\"Joe\"},\"relationships\":{\"friends\":{\"data\":[{\"id\":\"1\",\"type\":\"guest\"},{\"id\":\"2\",\"type\":\"guest\"},{\"id\":\"3\",\"type\":\"guest\"}]}}}," +
-            "{\"id\":\"60\",\"type\":\"guest\",\"attributes\":{\"age\":25,\"name\":\"Joe\"},\"relationships\":{}}]}"
+            "{\"id\":\"60\",\"type\":\"guest\",\"attributes\":{\"age\":25,\"name\":\"Joe\"},\"relationships\":{}}," +
+            "{\"id\":\"1\",\"type\":\"guest\",\"attributes\":{\"age\":25,\"name\":\"Joe\"}}]}"
           )
           validate_json_integrity(data)
         end

--- a/spec/fast-jsonapi-serializer_spec.cr
+++ b/spec/fast-jsonapi-serializer_spec.cr
@@ -151,6 +151,21 @@ describe FastJSONAPISerializer do
           validate_json_integrity(data)
         end
 
+        it "adds relations objects and skips included data" do
+          resource = Restaurant.new
+          resource.address = Address.new
+          rel_config = FastJSONAPISerializer::RelationshipConfig.parse({ :address => [:address] })
+          rel_config.embed(false)
+          data = RestaurantSerializer.new(resource).serialize(includes: rel_config)
+          data.should contain(%("included"))
+          data.should contain(%("relationships"))
+
+          data.should eq(
+            "{\"data\":{\"id\":\"1\",\"type\":\"restaurant\",\"attributes\":{\"name\":\"big burgers\",\"Rating\":\"Great!\",\"own_field\":12},\"relationships\":{\"address\":{\"data\":{\"id\":\"101\",\"type\":\"address\"}}}},\"included\":[]}"
+          )
+          validate_json_integrity(data)
+        end
+
         it "only includes objects to included data if relationship exists" do
           data = RestaurantSerializer.new(Restaurant.new).serialize(
             includes: {

--- a/spec/fast-jsonapi-serializer_spec.cr
+++ b/spec/fast-jsonapi-serializer_spec.cr
@@ -348,7 +348,7 @@ describe FastJSONAPISerializer do
               :vips   => [:vips],
             }
           )
-          ref_config.children.not_nil!.find { |node| node.name == :guests }.not_nil!.embed(false)
+          ref_config.traverse(:guests).embed(false)
           data = RestaurantSerializer.new(resource).serialize(includes: ref_config)
 
           data.should contain(%("included"))

--- a/spec/fast-jsonapi-serializer_spec.cr
+++ b/spec/fast-jsonapi-serializer_spec.cr
@@ -155,7 +155,7 @@ describe FastJSONAPISerializer do
           resource = Restaurant.new
           resource.address = Address.new
           rel_config = FastJSONAPISerializer::RelationshipConfig.parse({ :address => [:address] })
-          rel_config.embed(false)
+          rel_config.include?(false)
           data = RestaurantSerializer.new(resource).serialize(includes: rel_config)
           data.should contain(%("included"))
           data.should contain(%("relationships"))
@@ -213,7 +213,7 @@ describe FastJSONAPISerializer do
         end
 
         it "includes only relationsips objects and skips embedding data" do
-          rel_config = FastJSONAPISerializer::RelationshipConfig.parse({ :post_code => [:post_code] }).embed(false)
+          rel_config = FastJSONAPISerializer::RelationshipConfig.parse({ :post_code => [:post_code] }).include?(false)
           resource = Restaurant.new
           resource.post_code = PostCode.new
           data = RestaurantSerializer.new(resource).serialize(includes: rel_config)
@@ -275,7 +275,7 @@ describe FastJSONAPISerializer do
         it "adds relation objects and skips included data" do
           resource = Restaurant.new
           resource.rooms = [Room.new(1), Room.new(2)]
-          ref_config = FastJSONAPISerializer::RelationshipConfig.parse({ :rooms => [:rooms] }).embed(false)
+          ref_config = FastJSONAPISerializer::RelationshipConfig.parse({ :rooms => [:rooms] }).include?(false)
           data = RestaurantSerializer.new(resource).serialize(includes: ref_config)
           data.should contain(%("included"))
           data.should contain(%("relationships"))
@@ -348,7 +348,7 @@ describe FastJSONAPISerializer do
               :vips   => [:vips],
             }
           )
-          ref_config.traverse(:guests).embed(false)
+          ref_config.relationship(:guests).include?(false)
           data = RestaurantSerializer.new(resource).serialize(includes: ref_config)
 
           data.should contain(%("included"))

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,4 +1,5 @@
 require "spec"
+require "../src/fast-jsonapi-serializer/relationship_config"
 require "../src/fast-jsonapi-serializer"
 require "./support/**"
 

--- a/src/fast-jsonapi-serializer/base.cr
+++ b/src/fast-jsonapi-serializer/base.cr
@@ -391,7 +391,7 @@ module FastJSONAPISerializer
               io << "\"type\":" << serializer.get_type.to_json
               io << "}"
 
-              if relationships_container.add?(serializer.unique_key(sub_object)) && includes.embed
+              if relationships_container.add?(serializer.unique_key(sub_object)) && includes.included
                 data = String.build do |included_io|
                   serializer._serialize_json(sub_object, included_io, [] of Symbol, includes.nested(name), options)
                 end
@@ -408,7 +408,7 @@ module FastJSONAPISerializer
               fields_count = {{ superclass.methods.any?(&.name.==(:build_relationships.id)) ? :super.id : 0 }}
 
               {% for name, props in RELATIONS %}
-                if includes.have_relation?({{name}})
+                if includes.has_relation?({{name}})
                   io << "," unless fields_count.zero?
                   io << "\"{{props[:key].id}}\":{"
                   io << "\"data\":"

--- a/src/fast-jsonapi-serializer/base.cr
+++ b/src/fast-jsonapi-serializer/base.cr
@@ -391,7 +391,7 @@ module FastJSONAPISerializer
               io << "\"type\":" << serializer.get_type.to_json
               io << "}"
 
-              if relationships_container.add?(serializer.unique_key(sub_object)) && includes.included
+              if includes.relationship(name).included && relationships_container.add?(serializer.unique_key(sub_object))
                 data = String.build do |included_io|
                   serializer._serialize_json(sub_object, included_io, [] of Symbol, includes.nested(name), options)
                 end

--- a/src/fast-jsonapi-serializer/relationship_config.cr
+++ b/src/fast-jsonapi-serializer/relationship_config.cr
@@ -27,6 +27,10 @@ module FastJSONAPISerializer
       children.nil? || children.try &.empty?
     end
 
+    def traverse(path)
+      children.not_nil!.find { |child| child.name == path }.not_nil!
+    end
+
     def self.parse(config : Iterable)
       new(nil, build(config))
     end

--- a/src/fast-jsonapi-serializer/relationship_config.cr
+++ b/src/fast-jsonapi-serializer/relationship_config.cr
@@ -2,18 +2,18 @@ module FastJSONAPISerializer
   class RelationshipConfig
     getter name : Symbol?
     getter children : Array(RelationshipConfig)?
-    getter embed = true
+    getter included = true
 
     def initialize(@name = nil, @children = nil)
     end
 
-    def embed(@embed)
-      children.try &.each { |child| child.embed(@embed) }
+    def include?(@included)
+      children.try &.each { |child| child.include?(@included) }
 
       self
     end
 
-    def have_relation?(name : Symbol)
+    def has_relation?(name : Symbol)
       children.try &.any? { |rel| rel.name == name }
     end
 
@@ -27,7 +27,7 @@ module FastJSONAPISerializer
       children.nil? || children.try &.empty?
     end
 
-    def traverse(path)
+    def relationship(path)
       children.not_nil!.find { |child| child.name == path }.not_nil!
     end
 

--- a/src/fast-jsonapi-serializer/relationship_config.cr
+++ b/src/fast-jsonapi-serializer/relationship_config.cr
@@ -3,10 +3,10 @@ module FastJSONAPISerializer
     class RelationshipMissingException < Exception
       def initialize(relation : Symbol?)
         @message = if relation
-          "'#{relation}' association missing."
-        else
-          "Associations are not configured."
-        end
+                     "'#{relation}' association missing."
+                   else
+                     "Associations are not configured."
+                   end
       end
     end
 
@@ -28,7 +28,7 @@ module FastJSONAPISerializer
     end
 
     def nested(name : Symbol)
-      null_rel = self.class.new()
+      null_rel = self.class.new
 
       children.try &.find(null_rel) { |rel| rel.name == name } || null_rel
     end

--- a/src/fast-jsonapi-serializer/relationship_config.cr
+++ b/src/fast-jsonapi-serializer/relationship_config.cr
@@ -1,5 +1,15 @@
 module FastJSONAPISerializer
   class RelationshipConfig
+    class RelationshipMissingException < Exception
+      def initialize(relation : Symbol?)
+        @message = if relation
+          "'#{relation}' association missing."
+        else
+          "Associations are not configured."
+        end
+      end
+    end
+
     getter name : Symbol?
     getter children : Array(RelationshipConfig)?
     getter included = true
@@ -28,7 +38,11 @@ module FastJSONAPISerializer
     end
 
     def relationship(path)
-      children.not_nil!.find { |child| child.name == path }.not_nil!
+      raise RelationshipMissingException.new(nil) if children.nil?
+
+      rel = children.not_nil!.find { |child| child.name == path }
+      raise RelationshipMissingException.new(path) if rel.nil?
+      rel
     end
 
     def self.parse(config : Iterable)

--- a/src/fast-jsonapi-serializer/relationship_config.cr
+++ b/src/fast-jsonapi-serializer/relationship_config.cr
@@ -1,0 +1,53 @@
+module FastJSONAPISerializer
+  class RelationshipConfig
+    getter name : Symbol?
+    getter children : Array(RelationshipConfig)?
+    getter embed = true
+
+    def initialize(@name = nil, @children = nil)
+    end
+
+    def embed(@embed)
+      children.try &.each { |child| child.embed(@embed) }
+
+      self
+    end
+
+    def have_relation?(name : Symbol)
+      children.try &.any? { |rel| rel.name == name }
+    end
+
+    def nested(name : Symbol)
+      null_rel = self.class.new()
+
+      children.try &.find(null_rel) { |rel| rel.name == name } || null_rel
+    end
+
+    def empty?
+      children.nil? || children.try &.empty?
+    end
+
+    def self.parse(config : Iterable)
+      new(nil, build(config))
+    end
+
+    def self.build(arr : Array)
+      arr.map { |rel| self.build(rel) }
+    end
+
+    def self.build(hash : Hash)
+      hash.map do |rel_name, rels|
+        child = build(rels)
+        if child.is_a? Iterable
+          new(rel_name, child)
+        else
+          new(rel_name, [child])
+        end
+      end
+    end
+
+    def self.build(name : Symbol)
+      new(name)
+    end
+  end
+end

--- a/src/fast-jsonapi-serializer/relationships_container.cr
+++ b/src/fast-jsonapi-serializer/relationships_container.cr
@@ -1,0 +1,16 @@
+module FastJSONAPISerializer
+  class RelationshipsContainer
+    property content = Set(String).new
+    property included_keys = Set(Tuple(String, IDAny)).new
+
+    delegate :empty?, to: included_keys
+
+    def add?(item : Tuple(String, IDAny))
+      included_keys.add?(item)
+    end
+
+    def include_content(item : String)
+      content.add(item)
+    end
+  end
+end


### PR DESCRIPTION
Hi! First of all want to thank you for your work. It is really very pleasant, light and fast lib. 

In this PR I am adding abilitity to render relations only, without requirement to include associated objects later into `includes` array. 
The relations can be rendered in mixed way, so some configured relations will be included, and some not. The default behaviour is not changed, examples of usage can be found in specs. 

Will be glad to hear your feedback. Thank you!